### PR TITLE
#6 - Preserve service path for appsync constructor 🛡

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const createServer = require("@conduitvc/appsync-emulator-serverless/server");
 class ServerlessAppSyncPlugin {
   constructor(serverless, options) {
     this.serverless = serverless;
+    this.servicePath = serverless.config.servicePath;
     this.serverlessLog = serverless.cli.log.bind(serverless.cli);
     this.options = options;
 
@@ -95,7 +96,7 @@ class ServerlessAppSyncPlugin {
       }
 
       const serverless = path.join(
-        this.serverless.config.servicePath,
+        this.servicePath,
         "serverless.yml"
       );
       const port = this.options.port;


### PR DESCRIPTION
When you initialize the instance of appsync emulator you can pass wrong path of yml file, because other plugins (for example serverless-plugin-typescript) can mutate this.serverless object.

I solved this problem with storing of service path in object property `servicePath`.