### PR TITLE
Add graphQL schema path when the server emulation is started

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,9 @@ class ServerlessAppSyncPlugin {
         "serverless.yml"
       );
       const port = this.options.port;
-      const server = await createServer({ serverless, port, dynamodb });
+      // from "custom.appSync.schema" for custom graphQL schema file location
+      const schemaPath = this.options.schema;
+      const server = await createServer({ serverless, schemaPath, port, dynamodb });
       this.serverlessLog("AppSync started: " + server.url);
 
       this._listenSIGINT();


### PR DESCRIPTION
This checks if the custom appSync part of the serverless configuration has a altered schema path as documented in the serverless-appsync-plugin: 

```
custom:
  appSync:
    name:  "name"
    schema: "custompath/schema.graphql"
```

The path can be provided for the `createServer(...)` function with the optional `schemaPath` parameter as described at: https://github.com/ConduitVC/aws-utils/blob/dynamodb-emulator/packages/appsync-emulator-serverless/server.js#L58