### PR TITLE
Bump appsync emulator serverless version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "jest --no-cache"
   },
   "dependencies": {
-    "@conduitvc/appsync-emulator-serverless": "^0.7.3",
+    "@conduitvc/appsync-emulator-serverless": "^0.7.4",
     "aws-sdk": "^2.313.0",
     "lodash": "^4.17.10"
   },


### PR DESCRIPTION
Bump the version of the appsync-emulator-serverless because it was added support to run Go Lambdas.