### PR TITLE
Prevent process exit on start for newer serverless versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,10 +115,17 @@ class ServerlessAppSyncPlugin {
   }
 
   endHandler() {
-    this.serverlessLog("AppSync offline - stopping graphql and dynamoDB");
-    this.emulator.terminate().then(() => {
+    if (this.emulator) {
+      // DynamoDB only needs stopping if we actually started it. If an external
+      // connection was specified then this.emulator will be undefined.
+      this.serverlessLog("AppSync offline - stopping graphql and dynamoDB");
+      this.emulator.terminate().then(() => {
+        process.exit(0);
+      });
+    } else {
+      this.serverlessLog("AppSync offline - stopping graphql");
       process.exit(0);
-    });
+    }
   }
 
   _setOptions() {


### PR DESCRIPTION
[This change ](https://github.com/serverless/serverless/commit/a0a0fb1530fa17e9f215879dfdead88f61e46169)to the serverless package causes the serverless process to exit after running a command. 

To fix it, I've pinched some code from the `serverless-offline` package that returns an unresolved promise that waits for either `SIGINT` or `SIGTERM`.

This fixes https://github.com/aheissenberger/serverless-appsync-offline/issues/8