### PR TITLE
Update @conduitvc/appsync-emulator-serverless to 0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "jest --no-cache"
   },
   "dependencies": {
-    "@conduitvc/appsync-emulator-serverless": "^0.12.7",
+    "@conduitvc/appsync-emulator-serverless": "^0.14.0",
     "aws-sdk": "^2.463.0",
     "lodash": "^4.17.11"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-appsync-offline",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Serverless AWS AppSync Offline Plugin - Allow to run AppSync locally for serverless framework",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
✅Test pass 😇
✅Tested the plugin on our solution using sls offline and still works as expected

**@conduitvc/appsync-emulator-serverless** bumped their minor version, thought it would be good to bump **serverless-appsync-offline** as well as it's a major dependency for the package.