### PR TITLE
Fix broken child package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "@conduitvc/appsync-emulator-serverless": "^0.14.5",
     "aws-sdk": "^2.559.0",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "jsonschema": "1.2.6"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",


### PR DESCRIPTION
Due to a broken dependency, `sls appsync-offline start` was crashing on startup with the error :
```Serverless: ERROR: SchemaError: Expected `schema` to be an object or boolean```
See more about this issue here : https://stackoverflow.com/a/64198171/8541886

I changed [composer.json](https://github.com/aheissenberger/serverless-appsync-offline/pull/49/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to use the last compatible version of [jsonschema](https://www.npmjs.com/package/jsonschema), a dependency of [mosca](https://www.npmjs.com/package/mosca) witch was causing this issue